### PR TITLE
Update GoogleDistanceMatrix.php

### DIFF
--- a/src/GoogleDistanceMatrix.php
+++ b/src/GoogleDistanceMatrix.php
@@ -3,6 +3,7 @@
 namespace FinalBytes\GoogleDistanceMatrix;
 
 use GuzzleHttp\Client;
+use FinalBytes\GoogleDistanceMatrix\Response\GoogleDistanceMatrixResponse;
 
 class GoogleDistanceMatrix
 {


### PR DESCRIPTION
fixes class not found
php looks for FinalBytes\GoogleDistanceMatrix\GoogleDistanceMatrix by default